### PR TITLE
fix incorrect python-path

### DIFF
--- a/scouts_wwdb_api/apps/files/apps.py
+++ b/scouts_wwdb_api/apps/files/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class FilesConfig(AppConfig):
-    name = "files"
+    name = "apps.files"

--- a/scouts_wwdb_api/apps/oidc/apps.py
+++ b/scouts_wwdb_api/apps/oidc/apps.py
@@ -1,5 +1,5 @@
-from django.apps import AppConfig
+# from django.apps import AppConfig
 
 
-class WorkshopsConfig(AppConfig):
-    name = "workshops"
+# class WorkshopsConfig(AppConfig):
+#     name = "workshops"

--- a/scouts_wwdb_api/apps/workshops/apps.py
+++ b/scouts_wwdb_api/apps/workshops/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class WorkshopsConfig(AppConfig):
-    name = "workshops"
+    name = "apps.workshops"


### PR DESCRIPTION
- fix incorrect python-path for app.files
- fix incorrect python-path in app.workshops
- disable apps.py for oidc-module,  incorrect and not listed in settings.


should fix:
```
django.core.exceptions.ImproperlyConfigured: Cannot import 'workshops'. 
Check that 'apps.workshops.apps.WorkshopsConfig.name' is correct.
```